### PR TITLE
Fix review findings: notification action reliability, due-date consistency, and list identity

### DIFF
--- a/app/src/androidTest/java/com/hora/varisankya/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/hora/varisankya/ExampleInstrumentedTest.kt
@@ -1,4 +1,4 @@
-package com.hora.helloworld
+package com.hora.varisankya
 
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -19,6 +19,6 @@ class ExampleInstrumentedTest {
     fun useAppContext() {
         // Context of the app under test.
         val appContext = InstrumentationRegistry.getInstrumentation().targetContext
-        assertEquals("com.hora.helloworld", appContext.packageName)
+        assertEquals("com.hora.varisankya", appContext.packageName)
     }
 }

--- a/app/src/main/java/com/hora/varisankya/SearchActivity.kt
+++ b/app/src/main/java/com/hora/varisankya/SearchActivity.kt
@@ -15,6 +15,7 @@ import com.google.android.material.chip.ChipGroup
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import com.hora.varisankya.util.AnimationHelper
+import com.hora.varisankya.util.DateHelper
 
 class SearchActivity : BaseActivity() {
 
@@ -149,7 +150,14 @@ class SearchActivity : BaseActivity() {
                 .collection("subscriptions")
                 .get()
                 .addOnSuccessListener { snapshots ->
-                    allSubscriptions = snapshots.toObjects(Subscription::class.java)
+                    allSubscriptions = snapshots.toObjects(Subscription::class.java).map { sub ->
+                        val normalizedDueDate = sub.dueDate?.let { DateHelper.normalizeDueDate(it) }
+                        if (normalizedDueDate != sub.dueDate) {
+                            sub.copy(dueDate = normalizedDueDate)
+                        } else {
+                            sub
+                        }
+                    }
                     
                     val targetView = if (allSubscriptions.isEmpty()) emptyStateContainer else contentContainer
                     val otherView = if (allSubscriptions.isEmpty()) contentContainer else emptyStateContainer

--- a/app/src/main/java/com/hora/varisankya/SubscriptionAdapter.kt
+++ b/app/src/main/java/com/hora/varisankya/SubscriptionAdapter.kt
@@ -211,15 +211,25 @@ class SubscriptionAdapter(
         override fun getNewListSize(): Int = newList.size
 
         override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
-            // Assuming Subscription has a unique ID, otherwise fallback to name+cost+dueDate
-            // Using logic based on available fields since ID might not be exposed or reliable in this context if not stable
             val oldItem = oldList[oldItemPosition]
             val newItem = newList[newItemPosition]
-            // Ideally compare by ID if available. Let's assume user defined ID or unique fields.
-            // If explicit ID exists, use it. Based on Subscription class usage elsewhere (Firestore), it likely has an ID.
-            // But I don't see the Subscription class definition here. I'll rely on object reference or content for now if ID is missing.
-            // SAFEST: Compare critical business keys
-            return oldItem === newItem || (oldItem.name == newItem.name && oldItem.cost == newItem.cost) 
+
+            val oldId = oldItem.id
+            val newId = newItem.id
+            if (oldId != null && newId != null) {
+                return oldId == newId
+            }
+
+            if (oldId != null || newId != null) {
+                return false
+            }
+
+            return oldItem.name == newItem.name &&
+                oldItem.cost == newItem.cost &&
+                oldItem.dueDate == newItem.dueDate &&
+                oldItem.recurrence == newItem.recurrence &&
+                oldItem.category == newItem.category &&
+                oldItem.currency == newItem.currency
         }
 
         override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {

--- a/app/src/main/java/com/hora/varisankya/util/DateHelper.kt
+++ b/app/src/main/java/com/hora/varisankya/util/DateHelper.kt
@@ -2,12 +2,75 @@ package com.hora.varisankya.util
 
 import java.util.Calendar
 import java.util.Date
+import java.util.TimeZone
 
 object DateHelper {
 
+    /**
+     * MaterialDatePicker returns the selected day as UTC midnight millis.
+     * Convert that day into a stable local date value (stored at local noon).
+     */
+    fun fromPickerSelectionMillis(selectionUtcMillis: Long): Date {
+        val utc = Calendar.getInstance(TimeZone.getTimeZone("UTC")).apply {
+            timeInMillis = selectionUtcMillis
+        }
+        return localNoon(
+            utc.get(Calendar.YEAR),
+            utc.get(Calendar.MONTH),
+            utc.get(Calendar.DAY_OF_MONTH)
+        )
+    }
+
+    /**
+     * Convert a stored due date into UTC midnight millis for MaterialDatePicker selection.
+     */
+    fun toPickerSelectionMillis(date: Date): Long {
+        val normalized = normalizeDueDate(date)
+        val local = Calendar.getInstance().apply { time = normalized }
+        val utc = Calendar.getInstance(TimeZone.getTimeZone("UTC")).apply {
+            set(Calendar.YEAR, local.get(Calendar.YEAR))
+            set(Calendar.MONTH, local.get(Calendar.MONTH))
+            set(Calendar.DAY_OF_MONTH, local.get(Calendar.DAY_OF_MONTH))
+            set(Calendar.HOUR_OF_DAY, 0)
+            set(Calendar.MINUTE, 0)
+            set(Calendar.SECOND, 0)
+            set(Calendar.MILLISECOND, 0)
+        }
+        return utc.timeInMillis
+    }
+
+    /**
+     * Normalize stored due dates to a stable local-date representation.
+     * Legacy records saved from picker UTC-midnight are converted using UTC Y/M/D.
+     * Current records are treated using local Y/M/D.
+     */
+    fun normalizeDueDate(date: Date): Date {
+        val utc = Calendar.getInstance(TimeZone.getTimeZone("UTC")).apply { time = date }
+        val isUtcMidnight = utc.get(Calendar.HOUR_OF_DAY) == 0 &&
+            utc.get(Calendar.MINUTE) == 0 &&
+            utc.get(Calendar.SECOND) == 0 &&
+            utc.get(Calendar.MILLISECOND) == 0
+
+        return if (isUtcMidnight) {
+            localNoon(
+                utc.get(Calendar.YEAR),
+                utc.get(Calendar.MONTH),
+                utc.get(Calendar.DAY_OF_MONTH)
+            )
+        } else {
+            val local = Calendar.getInstance().apply { time = date }
+            localNoon(
+                local.get(Calendar.YEAR),
+                local.get(Calendar.MONTH),
+                local.get(Calendar.DAY_OF_MONTH)
+            )
+        }
+    }
+
     fun calculateNextDueDate(fromDate: Date, recurrence: String): Date? {
-        val cal = Calendar.getInstance()
-        cal.time = fromDate
+        val cal = Calendar.getInstance().apply {
+            time = normalizeDueDate(fromDate)
+        }
         cal.set(Calendar.HOUR_OF_DAY, 12)
         cal.set(Calendar.MINUTE, 0)
         cal.set(Calendar.SECOND, 0)
@@ -38,5 +101,18 @@ object DateHelper {
             }
         }
         return cal.time
+    }
+
+    private fun localNoon(year: Int, month: Int, dayOfMonth: Int): Date {
+        val local = Calendar.getInstance().apply {
+            set(Calendar.YEAR, year)
+            set(Calendar.MONTH, month)
+            set(Calendar.DAY_OF_MONTH, dayOfMonth)
+            set(Calendar.HOUR_OF_DAY, 12)
+            set(Calendar.MINUTE, 0)
+            set(Calendar.SECOND, 0)
+            set(Calendar.MILLISECOND, 0)
+        }
+        return local.time
     }
 }

--- a/app/src/test/java/com/hora/varisankya/ExampleUnitTest.kt
+++ b/app/src/test/java/com/hora/varisankya/ExampleUnitTest.kt
@@ -1,4 +1,4 @@
-package com.hora.helloworld
+package com.hora.varisankya
 
 import org.junit.Test
 


### PR DESCRIPTION
## Summary
This PR addresses the repo review findings end-to-end:

- Fixes notification `Mark Paid` reliability by keeping all Firestore work inside `goAsync()` lifecycle using suspend `await()` calls.
- Normalizes due-date handling to a stable local-date representation and uses shared helpers across picker/save/read/recurrence flows.
- Fixes subscription item identity in `DiffUtil` to use stable document IDs (with safer fallback only when IDs are absent).
- Fixes edit-sheet delete flow to trigger the parent refresh callback and only dismiss on successful delete.
- Updates test scaffolding package/app-id from stale `com.hora.helloworld` to `com.hora.varisankya`.

## Files changed
- `app/src/main/java/com/hora/varisankya/util/DateHelper.kt`
- `app/src/main/java/com/hora/varisankya/AddSubscriptionBottomSheet.kt`
- `app/src/main/java/com/hora/varisankya/viewmodel/MainViewModel.kt`
- `app/src/main/java/com/hora/varisankya/SubscriptionNotificationWorker.kt`
- `app/src/main/java/com/hora/varisankya/receiver/NotificationActionReceiver.kt`
- `app/src/main/java/com/hora/varisankya/SubscriptionAdapter.kt`
- `app/src/main/java/com/hora/varisankya/SearchActivity.kt`
- `app/src/main/java/com/hora/varisankya/PaymentBottomSheet.kt`
- `app/src/test/java/com/hora/varisankya/ExampleUnitTest.kt`
- `app/src/androidTest/java/com/hora/varisankya/ExampleInstrumentedTest.kt`

## Validation
- Tried running tests with JDK 17:
  - `JAVA_HOME=$(/usr/libexec/java_home -v 17) bash ./gradlew testDebugUnitTest --no-daemon`
- Build currently fails before compilation in this environment because AGP plugin resolution for `com.android.application` `9.0.0` is unavailable from configured repositories.
